### PR TITLE
Add full-stack habit tracker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# codex_playground
-Personal sandbox for experimenting with Codex, GPT, and AI-powered code generation.
+# Habit Tracker Example
+
+This repository contains a minimal full‑stack habit tracker with a FastAPI backend and a React frontend.
+
+## Requirements
+
+- Docker
+- docker-compose
+
+## Running the project
+
+```bash
+docker-compose up --build
+```
+
+The frontend will be available at [http://localhost:3000](http://localhost:3000) and the backend Swagger UI at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+### Backend Swagger
+Open your browser at `http://localhost:8000/docs` to explore the API.
+
+### Frontend
+Open [http://localhost:3000](http://localhost:3000) after running `docker-compose up`.
+
+### Manual API check
+Example using `curl` to create a user:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"name": "Alice", "email": "alice@example.com"}' \
+  http://localhost:8000/users
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,156 @@
+import datetime
+import os
+from typing import List, Optional
+
+from fastapi import FastAPI, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import create_engine, Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import declarative_base, sessionmaker, Session, relationship
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./habit.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+
+    habits = relationship("Habit", back_populates="owner")
+
+
+class Habit(Base):
+    __tablename__ = "habits"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(String)
+    frequency = Column(String, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"))
+
+    owner = relationship("User", back_populates="habits")
+    completions = relationship("HabitCompletion", back_populates="habit")
+
+
+class HabitCompletion(Base):
+    __tablename__ = "habit_completions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    habit_id = Column(Integer, ForeignKey("habits.id"))
+    date = Column(Date, default=datetime.date.today)
+
+    habit = relationship("Habit", back_populates="completions")
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class UserCreate(BaseModel):
+    name: str
+    email: str
+
+
+class UserRead(UserCreate):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class HabitCreate(BaseModel):
+    title: str
+    description: Optional[str] = None
+    frequency: str
+    user_id: int
+
+
+class HabitRead(HabitCreate):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TrackingCreate(BaseModel):
+    habit_id: int
+    date: datetime.date
+
+
+class TrackingRead(BaseModel):
+    id: int
+    habit_id: int
+    date: datetime.date
+
+    class Config:
+        orm_mode = True
+
+
+app = FastAPI(title="Habit Tracker API")
+
+
+@app.post("/users", response_model=UserRead)
+def create_user(user: UserCreate, db: Session = Depends(get_db)):
+    db_user = User(name=user.name, email=user.email)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.get("/users", response_model=List[UserRead])
+def list_users(db: Session = Depends(get_db)):
+    return db.query(User).all()
+
+
+@app.post("/habits", response_model=HabitRead)
+def create_habit(habit: HabitCreate, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.id == habit.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    db_habit = Habit(
+        title=habit.title,
+        description=habit.description,
+        frequency=habit.frequency,
+        user_id=habit.user_id,
+    )
+    db.add(db_habit)
+    db.commit()
+    db.refresh(db_habit)
+    return db_habit
+
+
+@app.get("/habits", response_model=List[HabitRead])
+def list_habits(db: Session = Depends(get_db)):
+    return db.query(Habit).all()
+
+
+@app.post("/tracking", response_model=TrackingRead)
+def track_habit(tracking: TrackingCreate, db: Session = Depends(get_db)):
+    habit = db.query(Habit).filter(Habit.id == tracking.habit_id).first()
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+    record = HabitCompletion(habit_id=tracking.habit_id, date=tracking.date)
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@app.get("/tracking", response_model=List[TrackingRead])
+def list_tracking(db: Session = Depends(get_db)):
+    return db.query(HabitCompletion).all()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+pydantic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend/app:/app/app
+      - db_data:/app
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    environment:
+      - VITE_API_URL=http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Habit Tracker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "habit-tracker-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import HabitList from './pages/HabitList';
+import AddHabit from './pages/AddHabit';
+import History from './pages/History';
+
+export default function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Habits</Link> |{' '}
+        <Link to="/add">Add Habit</Link> |{' '}
+        <Link to="/history">History</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<HabitList />} />
+        <Route path="/add" element={<AddHabit />} />
+        <Route path="/history" element={<History />} />
+      </Routes>
+    </Router>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AddHabit.jsx
+++ b/frontend/src/pages/AddHabit.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+export default function AddHabit() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [frequency, setFrequency] = useState('daily');
+  const [userId, setUserId] = useState(1);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    fetch(`${API_URL}/habits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description, frequency, user_id: Number(userId) })
+    }).then(() => {
+      setTitle('');
+      setDescription('');
+    });
+  };
+
+  return (
+    <div>
+      <h2>Add Habit</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" />
+        <input value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
+        <select value={frequency} onChange={e => setFrequency(e.target.value)}>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+        <input value={userId} onChange={e => setUserId(e.target.value)} type="number" placeholder="User ID" />
+        <button type="submit">Add</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/HabitList.jsx
+++ b/frontend/src/pages/HabitList.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+export default function HabitList() {
+  const [habits, setHabits] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/habits`)
+      .then(res => res.json())
+      .then(setHabits);
+  }, []);
+
+  return (
+    <div>
+      <h2>Habits</h2>
+      <ul>
+        {habits.map(h => (
+          <li key={h.id}>{h.title} - {h.frequency}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+export default function History() {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/tracking`)
+      .then(res => res.json())
+      .then(setItems);
+  }, []);
+
+  return (
+    <div>
+      <h2>History</h2>
+      <ul>
+        {items.map(i => (
+          <li key={i.id}>{i.habit_id} - {i.date}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add FastAPI backend with SQLite models and routes
- include React frontend built with Vite
- add Dockerfiles for backend and frontend
- add docker-compose for easy startup
- update README with running instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867eea640dc8332b4e6057f8489a98e